### PR TITLE
build: remove 'ramen-configurator' in the docker.

### DIFF
--- a/docker/Dockerfile-dev.in
+++ b/docker/Dockerfile-dev.in
@@ -115,7 +115,6 @@ RUN echo "Update opam packages for latest dessser" && \
 # Install all ramen dependencies using opam
 RUN cd /root && \
     git clone https://github.com/rixed/ramen.git && \
-    git clone https://github.com/PerformanceVision/ramen-configurator.git && \
     cd ramen && \
     git checkout v@PACKAGE_VERSION@ || git checkout master && \
     ./configure && \


### PR DESCRIPTION
It is not needed for ramen and it use an archived repo moreover.