### PR TITLE
completion: add '--version' and '--help' completion options.

### DIFF
--- a/src/RamenCompletion.ml
+++ b/src/RamenCompletion.ml
@@ -49,7 +49,9 @@ let complete_commands s =
       "choreographer", CliInfo.choreographer ;
       "useradd", CliInfo.useradd ;
       "userdel", CliInfo.userdel ;
-      "usermod", CliInfo.usermod ] in
+      "usermod", CliInfo.usermod ;
+      "--help", CliInfo.help ;
+      "--version", CliInfo.version ] in
   complete commands s
 
 let complete_global_options s =


### PR DESCRIPTION
Add them to `ramen  _completion ''`, so that a user cannot
mistakenly think that there are not '--help' option.

closes #1140