### PR TITLE
cli: add a health command for ramen.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -223,6 +223,7 @@ RAMEN_SOURCES = \
 	src/RamenArchivist.ml \
 	src/RamenExport.ml \
 	src/RamenTimeseries.ml \
+	src/RamenSyncZMQClientHelpers.ml \
 	src/RamenHttpHelpers.ml \
 	src/RamenGc.ml \
 	src/RamenRun.ml \
@@ -1053,6 +1054,7 @@ LINKED_FOR_TESTS = \
 	src/RamenExport.ml \
 	src/RamenTimeseries.ml \
 	src/RamenRun.ml \
+	src/RamenSyncZMQClientHelpers.ml \
 	src/RamenHttpHelpers.ml \
 	src/RamenApi.ml \
 	src/RamenMake.ml \

--- a/rmadmin/chart/TimeChartFunctionsEditor.cpp
+++ b/rmadmin/chart/TimeChartFunctionsEditor.cpp
@@ -153,6 +153,8 @@ void TimeChartFunctionsEditor::addOrFocus(
       /* Create a new function editor */
       TimeChartFunctionEditor *e = addFunctionByName(
         site, program, function, customizable);
+      conf::DashWidgetChart::Source defaultSrc { site, program, function };
+      e->setValue(defaultSrc);
       (void)functions->insertItem(t_i, e, fqName);
       functions->setCurrentIndex(t_i);
       return;

--- a/src/RamenCompletion.ml
+++ b/src/RamenCompletion.ml
@@ -50,6 +50,7 @@ let complete_commands s =
       "useradd", CliInfo.useradd ;
       "userdel", CliInfo.userdel ;
       "usermod", CliInfo.usermod ;
+      "health", CliInfo.health ;
       "--help", CliInfo.help ;
       "--version", CliInfo.version ] in
   complete commands s
@@ -439,6 +440,10 @@ let complete str () =
       | "usermod" ->
           [ "--username", CliInfo.username ;
             "--role", CliInfo.role ] @
+          copts false
+      | "health" ->
+          [ "--httpd", CliInfo.services_to_check_httpd ;
+            "--tunneld", CliInfo.services_to_check_tunneld ] @
           copts false
       | _ -> []) in
     complete completions (if last_tok_is_complete then "" else last_tok))

--- a/src/RamenConsts.ml
+++ b/src/RamenConsts.ml
@@ -202,6 +202,7 @@ struct
   let timeseries = "Extract a time series from an operation."
   let ps = "Display info about running programs."
   let profile = "Display profiling information about running programs."
+  let health = "Display info about health of ramen services."
   let test = "Test a configuration against one or several tests."
   let dequeue = "Dequeue a message from a ringbuffer."
   let summary = "Display informations about a ring-buffer."
@@ -382,6 +383,14 @@ struct
   let oldest_restored_site =
     "Age of the last active site (before current one was last active) to \
      be restored from the configuration snapshot (in seconds!)."
+  let services_to_check =
+    "Services to check with health command. (httpd and tunneld by default)"
+  let services_to_check_httpd =
+    "check http service"
+  let services_to_check_tunneld =
+    "check tunneld service"
+  let healthchecks_per_sec =
+    "number of healthchecks per seconds (6 by default)."
 end
 
 module WorkerCommands =

--- a/src/RamenHttpd.ml
+++ b/src/RamenHttpd.ml
@@ -28,7 +28,8 @@ let http_topics api graphite =
       (if graphite then graphite_topics else Set.empty) in
   Set.to_list topics
 
-let run_httpd conf server_url api table_prefix graphite fault_injection_rate =
+let run_httpd conf server_url api table_prefix graphite fault_injection_rate
+              healthchecks_per_sec =
   (* We take the port and URL prefix from the given URL but does not take
    * into account the hostname or the scheme. *)
   let url = CodecUrl.of_string server_url in
@@ -73,4 +74,4 @@ let run_httpd conf server_url api table_prefix graphite fault_injection_rate =
       RamenProcesses.dummy_nop ;
       (fun () ->
         RamenHttpHelpers.http_service
-          conf port url_prefix router fault_injection_rate topics) |]
+          conf port url_prefix router fault_injection_rate topics healthchecks_per_sec) |]

--- a/src/RamenSync.ml
+++ b/src/RamenSync.ml
@@ -49,6 +49,9 @@ struct
   and per_service_key =
     | Host
     | Port
+    (* healthbeat to check service are still alive *)
+    | Health
+    | NextHealth
 
   and per_worker_key =
     (* Set by the workers: *)
@@ -99,7 +102,9 @@ struct
   let print_per_service_key oc k =
     String.print oc (match k with
       | Host -> "host"
-      | Port -> "port")
+      | Port -> "port"
+      | Health -> "health"
+      | NextHealth -> "nexthealth")
 
   let print_per_instance oc k =
     String.print oc (match k with

--- a/src/RamenSyncZMQClient.ml
+++ b/src/RamenSyncZMQClient.ml
@@ -407,9 +407,10 @@ let with_locked_matching
 
 module Stage =
 struct
-  type t = | Conn | Auth | Sync
+  type t = | Conn | Auth | Sync | Config
   let to_string = function
     | Conn -> "Connection"
+    | Config -> "Upload config"
     | Auth -> "Authentication"
     | Sync -> "Synchronization"
   let print oc s =

--- a/src/RamenSyncZMQClientHelpers.ml
+++ b/src/RamenSyncZMQClientHelpers.ml
@@ -1,0 +1,19 @@
+open RamenHelpersNoLog
+open RamenSync
+open RamenSyncHelpers
+
+let send_service_conf ~while_ conf service_name port session =
+    let host_key = RamenSync.Key.(PerSite (conf.RamenConf.site, (PerService (service_name, Host)))) in
+    let port_key = RamenSync.Key.(PerSite (conf.RamenConf.site, (PerService (service_name, Port)))) in
+    let host_value = Value.RamenValue (T.VString (conf.RamenConf.site :> string)) in
+    let port_value = Value.RamenValue (T.VU16 (Stdint.Uint16.of_int port)) in
+    ZMQClient.send_cmd session ~while_ (Client.CltMsg.SetKey (host_key, host_value)) ;
+    ZMQClient.send_cmd session ~while_ (Client.CltMsg.SetKey (port_key, port_value))
+
+let send_healthcheck ~while_ ~now conf service_name healthchecks_per_sec session =
+  let hearth_key = Key.(PerSite (conf.C.site, (PerService (service_name, Health)))) in
+  let hearth_value = Value.RamenValue (T.VFloat now) in
+  ZMQClient.send_cmd session ~while_ (Client.CltMsg.SetKey (hearth_key, hearth_value)) ;
+  let next_hearth_key = Key.(PerSite (conf.C.site, (PerService (service_name, NextHealth)))) in
+  let next_hearth_value = Value.RamenValue (T.VFloat (now+.60./.healthchecks_per_sec)) in
+  ZMQClient.send_cmd session ~while_ (Client.CltMsg.SetKey (next_hearth_key, next_hearth_value))

--- a/src/RamenTests.ml
+++ b/src/RamenTests.ml
@@ -610,7 +610,7 @@ let run conf server_url api graphite
       thread_create (fun () ->
         set_thread_name "httpd" ;
         let conf = { conf with username = "_httpd" } in
-        RamenHttpd.run_httpd conf server_url api "" graphite 0.0)) in
+        RamenHttpd.run_httpd conf server_url api "" graphite 0.0 6.0)) in
   (* Helps with logs mangling: *)
   Unix.sleepf 0.5 ;
   (*

--- a/tests/features/api.feature.in
+++ b/tests/features/api.feature.in
@@ -121,3 +121,25 @@ Feature: Test Ramen API from the command line.
     And I run curl with arguments --data-binary '{"method":"get-timeseries","id":1,"params":{"since":0,"until":9,"time-step":60,"data":{"test/random_walk":{"select":["xyz","key"],"where":[{"lhs":"key","op":">=","rhs":"0"}]}}}}' http://localhost:8042
     # We are going to use a single bucket between 0 and 60, and by default the times are the end times for the API:
     Then curl must mention ""times":[60.0]"
+
+  Scenario: I run an healthcheck without any services
+     Given I run ramen with arguments health
+     Then ramen must mention "httpd: WRONG"
+     Then ramen must mention "tunneld: WRONG"
+     Then ramen must exit with status 256
+
+  Scenario: I run an healthcheck with only httpd running service
+     Given ramen httpd --url http://localhost:8042 --api is started
+     And I wait 3 seconds
+     And I run ramen with arguments health
+     Then ramen must mention "httpd: OK"
+     Then ramen must mention "tunneld: WRONG"
+     Then ramen must exit with status 256
+
+  Scenario: I run an healthcheck to check only http service with only httpd running service
+     Given ramen httpd --url http://localhost:8042 --api is started
+     And I wait 3 seconds
+     And I run ramen with arguments health --httpd
+     Then ramen must mention "httpd: OK"
+     Then ramen must not mention "tunneld: WRONG"
+     Then ramen must exit with status 0


### PR DESCRIPTION
This patch adds a command for ramen to check health of
httpd and tunneld network services.

closes #924