### PR TITLE
fix: z3 version detection

### DIFF
--- a/configure
+++ b/configure
@@ -5494,7 +5494,7 @@ fi
 fi
 
   # Check z3 version
-  Z3VERSION=$($Z3 --version | sed -n -e 's+^.*\([0-9].[0-9].[0-9]\).*$+\1+p')
+  Z3VERSION=$($Z3 --version | awk 'NR == 1 {print $3}')
 
 
   Z3_MIN_VERSION="4.6.0"

--- a/m4/z3.m4
+++ b/m4/z3.m4
@@ -22,7 +22,7 @@ AC_DEFUN([AC_CHECK_Z3],
     [AC_MSG_ERROR([Cannot find z3 in the path.])])
 
   # Check z3 version
-  Z3VERSION=$($Z3 --version | sed -n -e 's+^.*\([[0-9]].[[0-9]].[[0-9]]\).*$+\1+p')
+  Z3VERSION=$($Z3 --version | awk 'NR == 1 {print [$]3}')
   AC_SUBST([Z3VERSION])
 
   Z3_MIN_VERSION="4.6.0"


### PR DESCRIPTION
Previously, the version of z3 was only used for detecting versions of the form x.y.z where x, y and z are single digit numbers.

However, there are versions of z3 that do not fit this format.

For example, the version 4.8.10 (currently used) is seen as 4.8.1.

Another example: the current last official release is 4.11.2.

This commit fixes this issue.